### PR TITLE
Affected Issue(s): #1725968271

### DIFF
--- a/src/main/java/org/sidindonesia/bidanreport/config/property/LastIdProperties.java
+++ b/src/main/java/org/sidindonesia/bidanreport/config/property/LastIdProperties.java
@@ -7,7 +7,8 @@ import lombok.Data;
 
 @Data
 @Configuration
-@ConfigurationProperties(prefix = "mother-identity")
-public class MotherIdentityProperties {
-	private Long lastId = 0L;
+@ConfigurationProperties(prefix = "last-id")
+public class LastIdProperties {
+	private Long motherIdentityLastId = 0L;
+	private Long motherEditLastId = 0L;
 }

--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/listener/QontakAuthenticationListener.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/listener/QontakAuthenticationListener.java
@@ -2,11 +2,13 @@ package org.sidindonesia.bidanreport.integration.qontak.listener;
 
 import java.util.Optional;
 
-import org.sidindonesia.bidanreport.config.property.MotherIdentityProperties;
+import org.sidindonesia.bidanreport.config.property.LastIdProperties;
+import org.sidindonesia.bidanreport.domain.MotherEdit;
 import org.sidindonesia.bidanreport.domain.MotherIdentity;
 import org.sidindonesia.bidanreport.integration.qontak.property.QontakProperties;
 import org.sidindonesia.bidanreport.integration.qontak.request.QontakWhatsAppAuthRequest;
 import org.sidindonesia.bidanreport.integration.qontak.response.QontakWhatsAppAuthResponse;
+import org.sidindonesia.bidanreport.repository.MotherEditRepository;
 import org.sidindonesia.bidanreport.repository.MotherIdentityRepository;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
@@ -25,7 +27,8 @@ public class QontakAuthenticationListener implements ApplicationListener<Applica
 	private final QontakProperties qontakProperties;
 	private final WebClient webClient;
 	private final MotherIdentityRepository motherIdentityRepository;
-	private final MotherIdentityProperties motherIdentityProperties;
+	private final MotherEditRepository motherEditRepository;
+	private final LastIdProperties lastIdProperties;
 
 	@Override
 	public void onApplicationEvent(ApplicationReadyEvent event) {
@@ -61,7 +64,11 @@ public class QontakAuthenticationListener implements ApplicationListener<Applica
 	private void syncLastId() {
 		Optional<MotherIdentity> optMotherIdentity = motherIdentityRepository.findFirstByOrderByEventIdDesc();
 		if (optMotherIdentity.isPresent()) {
-			motherIdentityProperties.setLastId(optMotherIdentity.get().getEventId());
+			lastIdProperties.setMotherIdentityLastId(optMotherIdentity.get().getEventId());
+		}
+		Optional<MotherEdit> optMotherEdit = motherEditRepository.findFirstByOrderByEventIdDesc();
+		if (optMotherEdit.isPresent()) {
+			lastIdProperties.setMotherIdentityLastId(optMotherEdit.get().getEventId());
 		}
 		log.info("Sync-ed last ID from DB successfully.");
 	}

--- a/src/main/java/org/sidindonesia/bidanreport/repository/MotherEditRepository.java
+++ b/src/main/java/org/sidindonesia/bidanreport/repository/MotherEditRepository.java
@@ -1,8 +1,30 @@
 package org.sidindonesia.bidanreport.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.sidindonesia.bidanreport.domain.MotherEdit;
+import org.sidindonesia.bidanreport.repository.projection.MotherIdentityWhatsAppProjection;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MotherEditRepository extends BaseRepository<MotherEdit, Long> {
+	@Query(nativeQuery = true, value = "SELECT me.event_id AS eventId, me.mobile_phone_number AS mobilePhoneNumber, "
+		+ "(SELECT cm.full_name FROM {h-schema}client_mother cm "
+		+ "WHERE cm.base_entity_id = me.mother_base_entity_id ORDER BY cm.server_version_epoch DESC LIMIT 1) AS fullName "
+		+ "FROM {h-schema}mother_edit me "
+		+ "WHERE me.event_id IN (SELECT MAX(me_id_only.event_id) OVER (PARTITION BY me_id_only.mother_base_entity_id)"
+		+ " FROM {h-schema}mother_edit me_id_only WHERE me_id_only.event_id > ?1"
+		+ " AND me_id_only.mobile_phone_number IS NOT NULL AND me_id_only.provider_id NOT LIKE '%demo%'"
+		+ " AND me_id_only.mother_base_entity_id IN (SELECT mi.mother_base_entity_id"
+		+ "  FROM {h-schema}mother_identity mi WHERE mi.mobile_phone_number IS NULL)"
+		+ " AND me_id_only.mother_base_entity_id NOT IN (SELECT me_duplicate.mother_base_entity_id"
+		+ "  FROM {h-schema}mother_edit me_duplicate WHERE me_duplicate.mobile_phone_number IS NOT NULL"
+		+ "  AND me_duplicate.event_id <= ?1 AND me_duplicate.provider_id NOT LIKE '%demo%')"
+		+ ") ORDER BY me.event_id")
+	List<MotherIdentityWhatsAppProjection> findAllMotherEditsWhichLastEditAndPreviouslyInMotherIdentityHasMobilePhoneNumberIsNullOrderByEventId(
+		Long motherEditLastId);
+
+	Optional<MotherEdit> findFirstByOrderByEventIdDesc();
 }

--- a/src/test/java/org/sidindonesia/bidanreport/integration/qontak/service/WhatsAppMessageServiceTest.java
+++ b/src/test/java/org/sidindonesia/bidanreport/integration/qontak/service/WhatsAppMessageServiceTest.java
@@ -2,9 +2,9 @@ package org.sidindonesia.bidanreport.integration.qontak.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sidindonesia.bidanreport.IntegrationTest;
 import org.sidindonesia.bidanreport.integration.qontak.property.QontakProperties;
@@ -34,20 +34,49 @@ class WhatsAppMessageServiceTest {
 	@Autowired
 	private JdbcOperations jdbcOperations;
 
-	@BeforeEach
-	void setUp() {
-		IntStream.rangeClosed(1, 2).forEach(id -> {
+	void insertDummyData() {
+		IntStream.rangeClosed(1, 2).forEach(insertIntoClientMother());
+		IntStream.rangeClosed(1, 3).forEach(insertIntoMotherIdentity());
+
+		IntStream.rangeClosed(4, 5).forEach(insertIntoClientMother());
+		IntStream.rangeClosed(4, 6).forEach(insertIntoMotherIdentityWithoutMobilePhoneNumber());
+		IntStream.rangeClosed(7, 9).forEach(insertIntoMotherEdit());
+	}
+
+	private IntConsumer insertIntoClientMother() {
+		return id -> {
 			jdbcOperations.execute("INSERT INTO client_mother\n"
 				+ "(source_id, date_created, base_entity_id, birth_date, server_version_epoch, source_date_deleted, full_name)\n"
 				+ "VALUES(" + id + ", CURRENT_TIMESTAMP, '" + id + "', CURRENT_TIMESTAMP, '157663657225" + id
 				+ "', CURRENT_TIMESTAMP, 'Test " + id + "');\n");
-		});
-		IntStream.rangeClosed(1, 3).forEach(id -> {
+		};
+	}
+
+	private IntConsumer insertIntoMotherIdentity() {
+		return id -> {
 			jdbcOperations.execute("INSERT INTO mother_identity\n"
 				+ "(event_id, date_created, event_date, mobile_phone_number, mother_base_entity_id, provider_id, registration_date, server_version_epoch, source_date_deleted, transfer_date)\n"
 				+ "VALUES(" + id + ", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '08381234567" + id + "', '" + id
 				+ "', 'test', CURRENT_TIMESTAMP, '157663657225" + id + "', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);\n");
-		});
+		};
+	}
+
+	private IntConsumer insertIntoMotherIdentityWithoutMobilePhoneNumber() {
+		return id -> {
+			jdbcOperations.execute("INSERT INTO mother_identity\n"
+				+ "(event_id, date_created, event_date, mother_base_entity_id, provider_id, registration_date, server_version_epoch, source_date_deleted, transfer_date)\n"
+				+ "VALUES(" + id + ", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '" + id
+				+ "', 'test', CURRENT_TIMESTAMP, '157663657225" + id + "', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);\n");
+		};
+	}
+
+	private IntConsumer insertIntoMotherEdit() {
+		return id -> {
+			jdbcOperations.execute("INSERT INTO mother_edit\n"
+				+ "(event_id, date_created, event_date, mobile_phone_number, mother_base_entity_id, provider_id, registration_date, server_version_epoch, source_date_deleted, transfer_date)\n"
+				+ "VALUES(" + id + ", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '08381234567" + id + "', '" + (id - 3)
+				+ "', 'test', CURRENT_TIMESTAMP, '157663657225" + id + "', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);\n");
+		};
 	}
 
 	@Test
@@ -79,7 +108,14 @@ class WhatsAppMessageServiceTest {
 	}
 
 	@Test
-	void testSendWhatsAppMessageToNewMothers() {
+	void testSendWhatsAppMessageToNewMothers_withHappyFlow() {
+		insertDummyData();
+		assertThat(whatsAppMessageService).isNotNull();
+		whatsAppMessageService.sendWhatsAppMessageToNewMothers();
+	}
+
+	@Test
+	void testSendWhatsAppMessageToNewMothers_withNoNewMothers() {
 		assertThat(whatsAppMessageService).isNotNull();
 		whatsAppMessageService.sendWhatsAppMessageToNewMothers();
 	}


### PR DESCRIPTION
What this commit has achieved:
1. Added logic for `mother_edit` send join notification via WhatsApp,
only send to from mothers which previously has `mobile_phone_number` =
`NULL` in table `mother_identity`
2. Tested using Qontak Mock server successfully
3. Added dummy data for covering the edit case