### PR TITLE
Affected Issue(s): #1725968271

### DIFF
--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/response/QontakWhatsAppBroadcastResponse.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/response/QontakWhatsAppBroadcastResponse.java
@@ -20,6 +20,6 @@ public class QontakWhatsAppBroadcastResponse {
 	@Data
 	public static class ErrorObj {
 		private Integer code;
-		private List<String> messages;
+		private List<Object> messages;
 	}
 }


### PR DESCRIPTION
What this commit has achieved:
1. Fix
```
java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT
at line 1 column 52 path $.error.messages[0]
```