### PR TITLE
Affected Issue(s): #1852786370

### DIFF
--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/VisitReminderService.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/VisitReminderService.java
@@ -25,7 +25,7 @@ public class VisitReminderService {
 	private final MotherEditRepository motherEditRepository;
 	private final BroadcastMessageService broadcastMessageService;
 
-	@Scheduled(cron = "${scheduling.visit-reminder.cron}", zone = "${scheduling.visit-reminder.zone}", initialDelayString = "${scheduling.visit-reminder.initial-delay-in-ms}")
+	@Scheduled(cron = "${scheduling.visit-reminder.cron}", zone = "${scheduling.visit-reminder.zone}")
 	public void sendVisitRemindersToEnrolledMothers() {
 		log.debug("Executing scheduled \"Send Visit Reminder via WhatsApp\"...");
 		log.debug("Send visit reminder to all mothers with -"

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -52,4 +52,3 @@ scheduling:
   visit-reminder:
     cron: "0 0 8 * * ?" # At 08:00 AM
     zone: Asia/Jakarta
-    initial-delay-in-ms: 60000 # 1 minute


### PR DESCRIPTION
What this commit has achieved:
1. Resolved issue from WARN message
```2021-11-05 15:05:49.853  WARN 4630 --- [           main]
ConfigServletWebServerApplicationContext : Exception encountered during
context initialization - cancelling refresh attempt:
org.springframework.beans.factory.BeanCreationException: Error creating
bean with name 'visitReminderService' defined in URL
[jar:file:/opt/bidan-report/bidan-report-2.4.0.war!/WEB-INF/classes!/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/VisitReminderService.class]:
Initialization of bean failed; nested exception is
java.lang.IllegalStateException: Encountered invalid @Scheduled method
'sendVisitRemindersToEnrolledMothers': 'initialDelay' not supported for
cron triggers```