### PR TITLE
cannot execute INSERT in a read-only transaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.sidindonesia.bidanreport</groupId>
   <artifactId>bidan-report</artifactId>
-  <version>2.6.0</version>
+  <version>2.6.1</version>
   <packaging>war</packaging>
   <name>bidan-report</name>
   <description>Generated from https://github.com/sid-indonesia/web-rest-archetype</description>

--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/HealthEducationService.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/HealthEducationService.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class HealthEducationService {
 	private final QontakProperties qontakProperties;

--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/IntroMessageService.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/IntroMessageService.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class IntroMessageService {
 	private final MotherIdentityRepository motherIdentityRepository;

--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/PregnancyGapService.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/PregnancyGapService.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class PregnancyGapService {
 	private final QontakProperties qontakProperties;

--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/VisitReminderService.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/whatsapp/service/VisitReminderService.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class VisitReminderService {
 	private final QontakProperties qontakProperties;


### PR DESCRIPTION
https://www.notion.so/sid-indonesia/Improve-data-completeness-care-coverage-etc-by-adding-integration-with-Qontak-WhatsApp-API-to-sen-b6b404d36c264cb293d2a7a1a356006d

What this commit has achieved:
1. Fixed
```
org.postgresql.util.PSQLException: ERROR: cannot execute INSERT in a
read-only transaction
```
by removing hint `readOnly = true` in annotation `@Transactional`.
Because at the end of the scheduled task is upsert
`automated_message_stats`