### PR TITLE
Affected Issue(s): https://www.notion.so/sid-indonesia/Wrong-criteria-on-automated_message_stats-query-upsert-31efc03fa7694ea4ae2674f968caf0a0

### DIFF
--- a/src/main/java/org/sidindonesia/bidanreport/integration/qontak/repository/AutomatedMessageStatsRepository.java
+++ b/src/main/java/org/sidindonesia/bidanreport/integration/qontak/repository/AutomatedMessageStatsRepository.java
@@ -15,10 +15,10 @@ public interface AutomatedMessageStatsRepository extends JpaRepository<Automated
 		+ " successful_attempts, " + " failed_attempts) " + "VALUES(?1, " + "?2, " + "?3, " + "?4)  " + "ON "
 		+ "CONFLICT (message_template_id)  " + "DO " + "UPDATE " + "SET " + " message_template_name = ?2, "
 		+ " successful_attempts = ( " + " SELECT " + "  successful_attempts " + " FROM "
-		+ "  {h-schema}automated_message_stats " + " WHERE " + "  message_template_id = message_template_id "
+		+ "  {h-schema}automated_message_stats " + " WHERE " + "  message_template_id = ?1 "
 		+ " ORDER BY " + "  successful_attempts DESC " + " LIMIT 1) + ?3, " + " failed_attempts = ( " + " SELECT "
 		+ "  failed_attempts " + " FROM " + "  {h-schema}automated_message_stats " + " WHERE "
-		+ "  message_template_id = message_template_id " + " ORDER BY " + "  failed_attempts DESC " + " LIMIT 1) + ?4")
+		+ "  message_template_id = ?1 " + " ORDER BY " + "  failed_attempts DESC " + " LIMIT 1) + ?4")
 	int upsert(String messageTemplateId, String messageTemplateName, long successfulAttempts, long failedAttempts);
 
 }


### PR DESCRIPTION
https://www.notion.so/sid-indonesia/Wrong-criteria-on-automated_message_stats-query-upsert-31efc03fa7694ea4ae2674f968caf0a0

What this commit has achieved:
1. Fixed wrong criteria on `upsert` query for table
`automated_message_stats`